### PR TITLE
Add Table test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -28,6 +29,11 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.1",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/Table.test.tsx
+++ b/src/Table.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import React from 'react'
+import Table from './Table'
+
+describe('Table', () => {
+  it('shows no data message when data is empty', () => {
+    render(<Table data={[]} />)
+    expect(
+      screen.getByText(
+        'No data available. Please select an endpoint from the button group above.'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- set up vitest React testing utilities
- configure vitest in vite config
- add a `Table` component test

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fd2978f4832a91b9b79614fdb280