### PR TITLE
Handle single-object responses in Table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ export default function App() {
         </h1>
         
         <ButtonGroup onFetch={setJsonData} />
-        <Table data={jsonData || []} />
+        <Table data={jsonData} />
       </div>
     </div>
   )

--- a/src/Table.test.tsx
+++ b/src/Table.test.tsx
@@ -12,4 +12,10 @@ describe('Table', () => {
       )
     ).toBeInTheDocument()
   })
+
+  it('renders table rows when data is an object', () => {
+    const obj = { id: 1, name: 'Alice' }
+    render(<Table data={obj} />)
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+  })
 })

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -4,8 +4,10 @@ interface JsonData {
   [key: string]: any
 }
 
-export default function Table({ data }: { data: JsonData[] }) {
-  if (!data || data.length === 0) {
+export default function Table({ data }: { data: JsonData | JsonData[] | null }) {
+  const rows: JsonData[] = Array.isArray(data) ? data : data ? [data] : []
+
+  if (rows.length === 0) {
     return (
       <div className="text-center py-8 text-gray-500">
         <p>No data available. Please select an endpoint from the button group above.</p>
@@ -14,7 +16,7 @@ export default function Table({ data }: { data: JsonData[] }) {
   }
 
   // Extract column headers from the first item
-  const columns = Object.keys(data[0] || {})
+  const columns = Object.keys(rows[0] || {})
   
   return (
     <div className="overflow-x-auto">
@@ -32,7 +34,7 @@ export default function Table({ data }: { data: JsonData[] }) {
           </tr>
         </thead>
         <tbody className="bg-white divide-y divide-gray-200">
-          {data.map((row: JsonData, rowIndex: number) => (
+          {rows.map((row: JsonData, rowIndex: number) => (
             <tr 
               key={rowIndex} 
               className={rowIndex % 2 === 0 ? 'bg-gray-50' : 'bg-white'}


### PR DESCRIPTION
## Summary
- allow `Table` to accept a single object or array
- show fetched data in `Table` without forcing an array in `App`
- test object support in `Table`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842fdd97800832a8b8087906da64f17